### PR TITLE
mmcai-setup.sh: find secret

### DIFF
--- a/mmcai-setup.sh
+++ b/mmcai-setup.sh
@@ -96,23 +96,26 @@ function helm_login() {
     else
         div
         log_bad "Helm login was unsuccessful."
-        log_bad "Please provide an mmcai-ghcr-secret.yaml that allows helm login."
+        log_bad "Please provide an $MMCAI_GHCR_SECRET that allows helm login."
         div
         log "Report:"
-        cat mmcai-ghcr-secret.yaml
+        cat $MMCAI_GHCR_PATH
         div
         exit 1
     fi
 }
 
-if [[ -f "mmcai-ghcr-secret.yaml" ]]; then
-    kubectl apply -f mmcai-ghcr-secret.yaml
-    helm registry logout ghcr.io/memverge
-    helm_login
-else
-    kubectl create ns $NAMESPACE
-    kubectl create ns mmcloud-operator-system
+if ! kubectl apply -f $MMCAI_GHCR_PATH; then
+    log_bad "Applying $MMCAI_GHCR_PATH failed. Exiting..."
+    
+    sleep 1
+    
+    exit 1
 fi
+
+helm registry logout ghcr.io/memverge
+
+helm_login
 
 ## Create monitoring namespace
 

--- a/mmcai-setup.sh
+++ b/mmcai-setup.sh
@@ -9,13 +9,14 @@ log_good "Welcome to MMC.AI setup!"
 div
 
 NAMESPACE="mmcai-system"
-MMCAI_GHCR_PATH="./mmcai-ghcr-secret.yaml"
+MMCAI_GHCR_SECRET="mmcai-ghcr-secret.yaml"
+MMCAI_GHCR_PATH="./$MMCAI_GHCR_SECRET"
 
 function usage() {
     div
     echo "$0 [-f yaml]: MMC.AI setup wizard."
-    echo "    -f: takes a path to ${SECRET_YAML}."
-    echo "        By default, the script checks if ${SECRET_YAML} exists in the current directory."
+    echo "    -f: Takes a path to ${MMCAI_GHCR_SECRET}."
+    echo "        By default, the script checks if ${MMCAI_GHCR_SECRET} exists in the current directory."
     echo "        If not, then this argument must be provided."
     div
 }
@@ -42,11 +43,11 @@ function get_opts() {
 
 function find_secret() {
     if [ -f "$MMCAI_GHCR_PATH" ]; then
-        log "Found mmcai-ghcr-secret.yaml in $MMCAI_GHCR_PATH. Continuing..."
+        log "Found $MMCAI_GHCR_SECRET at $MMCAI_GHCR_PATH. Continuing..."
         return
     fi
 
-    log_bad "Could not find mmcai-ghcr-secret.yaml. Exiting..."
+    log_bad "Could not find $MMCAI_GHCR_SECRET at $MMCAI_GHCR_PATH. See usage:"
     
     sleep 1
     
@@ -55,7 +56,7 @@ function find_secret() {
     exit 1
 }
 
-get_opts
+get_opts ${@}
 
 find_secret
 
@@ -71,7 +72,7 @@ div
 log_good "Creating directories for billing database:"
 div
 
-wget -O mysql-pre-setup.sh https://raw.githubusercontent.com/MemVerge/mmc.ai-setup/main/mysql-pre-setup.sh
+wget -q -O mysql-pre-setup.sh https://raw.githubusercontent.com/MemVerge/mmc.ai-setup/main/mysql-pre-setup.sh
 chmod +x mysql-pre-setup.sh
 ./mysql-pre-setup.sh
 

--- a/mmcai-setup.sh
+++ b/mmcai-setup.sh
@@ -5,10 +5,59 @@ source logging.sh
 ## welcome message
 
 div
-log "Welcome to MMC.AI setup!"
+log_good "Welcome to MMC.AI setup!"
 div
 
 NAMESPACE="mmcai-system"
+MMCAI_GHCR_PATH="./mmcai-ghcr-secret.yaml"
+
+function usage() {
+    div
+    echo "$0 [-f yaml]: MMC.AI setup wizard."
+    echo "    -f: takes a path to ${SECRET_YAML}."
+    echo "        By default, the script checks if ${SECRET_YAML} exists in the current directory."
+    echo "        If not, then this argument must be provided."
+    div
+}
+
+function get_opts() {
+    while getopts "f:" opt; do
+    case $opt in
+        f)
+            MMCAI_GHCR_PATH="$OPTARG"
+            ;;
+        \?)
+            log_bad "Invalid option: -$OPTARG" >&2
+            usage
+            exit 1
+            ;;
+        :)
+            log_bad "Option -$OPTARG requires an argument." >&2
+            usage
+            exit 1
+            ;;
+    esac
+    done
+}
+
+function find_secret() {
+    if [ -f "$MMCAI_GHCR_PATH" ]; then
+        log "Found mmcai-ghcr-secret.yaml in $MMCAI_GHCR_PATH. Continuing..."
+        return
+    fi
+
+    log_bad "Could not find mmcai-ghcr-secret.yaml. Exiting..."
+    
+    sleep 1
+    
+    usage
+
+    exit 1
+}
+
+get_opts
+
+find_secret
 
 div
 log_good "Please provide information for billing database:"


### PR DESCRIPTION
Since we use the same credentials for helm login as github container registry, it's good to just pass the secret yaml into setup and have it do the logins, et cetera. Also let the user specify the .yaml via a cmdline argument.

Tested it on EC2 and it seems to work; thinking to merge to let QA run it a few times before release.

