### PR TITLE
Add time to log name; Skip log prompt during "force"

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -4,9 +4,10 @@
 # arg1 = path to log file. If empty, save to current directory
 TEE=("$(command -v tee)")               # Path to tee
 TAIL=("$(command -v tail)")             # Path to tail
+DATE=$(date +"%d_%b_%Y_%T")
 SCRIPT_NAME=${0##*/}                    # Name of this script
 SCRIPT_NAME=${SCRIPT_NAME%.*}           # Name of this without extension
-STDOUT_LOG_FILE="${SCRIPT_NAME}.log"    # Filename to save STDOUT and STDERR
+STDOUT_LOG_FILE="${SCRIPT_NAME}_${DATE}.log"    # Filename to save STDOUT and STDERR
 log_stdout_stderr() {
     local LOG_PATH
     if [[ $1 != "" ]]; then
@@ -75,7 +76,7 @@ case $1 in
       echo "Exiting..."
       exit 1
     else
-        initialize_log
+      initialize_log
     fi
     ;;
 esac


### PR DESCRIPTION
When I was running `helm uninstall mmai -n cattle-system; ./cleanup.sh force` I realized that the cleanup command can hang on the logfile prompt even if force is provided. Changes:

1. change the default logname so that it has a date at the end.
2. if "force" is provided and there's already a file with the default name, we append ".2"; if a "file.2" already exists, we take the number and increment it by one.
3. if "force" is not provided, ask for the logname after the continue (y/n) prompt.