### PR TITLE
Cleanup node labels

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -525,3 +525,10 @@ done
 for CRD in $(kubectl get crd -o name | grep -e mmai\.io -e kueue\.x-k8s\.io -e mmcloud\.io -e nvidia\.com -e nfd\.k8s-sigs\.io -e hami\.io); do
   kcd "$CRD"
 done
+
+# Remove MMAI labels from nodes
+for node in $(kubectl get nodes -o name); do
+  if kubectl get "$node" -o jsonpath="{.metadata.labels}" | grep -q mmai\.io; then
+    kubectl label "$node" mmai.io/nodegroup- mmai.io/fractional-gpu- node.kubernetes.io/unschedulable-
+  fi
+done


### PR DESCRIPTION
If a node has `mmai.io/nodegroup` label before a fresh install, it can't be added to any nodegoup. This cleanup script should cleanup labels added by MMAI.