### PR TITLE
Fix <details> in gh-pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+group :jekyll_plugins do
+    gem 'jekyll-commonmark-ghpages'
+  end

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,4 @@
+markdown: CommonMarkGhPages
+commonmark:
+  options: [ "UNSAFE", "SMART", "FOOTNOTES" ]
+  extensions: [ "strikethrough", "autolink", "table", "tagfilter" ]


### PR DESCRIPTION
The `<details>...</details>` sections currently do not work well in the gh-pages deployment:
![image](https://github.com/user-attachments/assets/b460a7b7-c063-4ff5-bdcd-65560aae5369)

The solution from https://github.com/github/jekyll-commonmark-ghpages can fix it.